### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2.1
+
+jobs:
+  build:
+    machine: true
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
+      - checkout
+      - save_cache:
+          key: source-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ".git"
+      - run: ./build-kernel.sh
+      - store_artifacts:
+          path: build
+          destination: build


### PR DESCRIPTION
This adds configuration for CircleCI that builds the kernel using the `build-kernel.sh` script.
It then makes the built kernel `tar.gz` file as well as the sha256 file available as an artifact for download.
For an example see https://circleci.com/gh/monome/linux/5#artifacts/containers/0

We can use this to get feedback on PRs that the build works/passes and then download the generated artifact to test on norns.

The caching of the `.git` directory is there because this repo is pretty large (1.7GB :open_mouth:) since it carries all of the kernel's history and there's currently no way to set the clone depth on CircleCI.

We can increment on this by letting it publish the `.tar.gz` and the sha256 when we create a release, though we probably want to filter out the upstream tags for that since we don't want to create releases for those. Something to figure out later :)

This relates to #9 but doesn't fix it yet since we're still missing the automatic publishing of the artifact for releases.