### PR TITLE
Add pin overrides to overlays in order to enable norns-shield

### DIFF
--- a/arch/arm/boot/dts/overlays/norns-buttons-encoders-overlay.dts
+++ b/arch/arm/boot/dts/overlays/norns-buttons-encoders-overlay.dts
@@ -31,13 +31,6 @@
             };
         };
     };
-    //__overrides__ {
-        //relative_axis =  <&knob>,"rotary-encoder,relative-axis";
-        //linux_axis =  <&knob>,"linux,axis";
-        //rollover =  <&knob>,"rotary-encoder,rollover";
-        //half-period =  <&knob>,"rotary-encoder,half-period";
-        //steps =  <&knob>,"rotary-encoder,steps";
-    //};
 
     fragment@2 {
         target-path = "/soc/gpio";
@@ -66,13 +59,6 @@
             };
         };
     };
-    //__overrides__ {
-        //relative_axis =  <&knob>,"rotary-encoder,relative-axis";
-        //linux_axis =  <&knob>,"linux,axis";
-        //rollover =  <&knob>,"rotary-encoder,rollover";
-        //half-period =  <&knob>,"rotary-encoder,half-period";
-        //steps =  <&knob>,"rotary-encoder,steps";
-    //};
 
     fragment@4 {
         target-path = "/soc/gpio";
@@ -88,7 +74,7 @@
     fragment@5 {
         target-path = "/soc";
         __overlay__ {
-            knob0: knob3 {
+            knob3: knob3 {
                 compatible = "rotary-encoder";
                 #address-cells = <1>;
                 #size-cells = <0>;
@@ -101,13 +87,6 @@
             };
         };
     };
-    //__overrides__ {
-        //relative_axis =  <&knob>,"rotary-encoder,relative-axis";
-        //linux_axis =  <&knob>,"linux,axis";
-        //rollover =  <&knob>,"rotary-encoder,rollover";
-        //half-period =  <&knob>,"rotary-encoder,half-period";
-        //steps =  <&knob>,"rotary-encoder,steps";
-    //};
 
     fragment@6 {
        target-path = "/";
@@ -116,19 +95,37 @@
              compatible = "gpio-keys";
              #address-cells = <1>;
              #size-cells = <0>;
-             button@31 {
+             button1: button1 {
                 linux,code = <1>;
                 gpios = <&gpio 31 1>;
              };
-             button@35 {
+             button2: button2 {
                 linux,code = <2>;
                 gpios = <&gpio 35 1>;
              };
-             button@39 {
+             button3: button3 {
                 linux,code = <3>;
                 gpios = <&gpio 39 1>;
              };
           };
        };
+    };
+
+    __overrides__ {
+        e1_pin_a = <&knob_pins1>,"brcm,pins:0",
+                   <&knob1>,"gpios:4";
+        e1_pin_b = <&knob_pins1>,"brcm,pins:4",
+                   <&knob1>,"gpios:16";
+        e2_pin_a = <&knob_pins2>,"brcm,pins:0",
+                   <&knob2>,"gpios:4";
+        e2_pin_b = <&knob_pins2>,"brcm,pins:4",
+                   <&knob2>,"gpios:16";
+        e3_pin_a = <&knob_pins3>,"brcm,pins:0",
+                   <&knob3>,"gpios:4";
+        e3_pin_b = <&knob_pins3>,"brcm,pins:4",
+                   <&knob3>,"gpios:16";
+        b1_pin = <&button1>,"gpios:4";
+        b2_pin = <&button2>,"gpios:4";
+        b3_pin = <&button3>,"gpios:4";
     };
 };

--- a/arch/arm/boot/dts/overlays/ssd1322-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ssd1322-spi-overlay.dts
@@ -74,6 +74,7 @@ RESET# = GPIO6
     rotate		= <&ssd1322>,"rotate:0";
     bgr				= <&ssd1322>,"bgr:0";
     fps				= <&ssd1322>,"fps:0";
-    debug			= <&ssd1322>,"debug:0";
+    debug     = <&ssd1322>,"debug:0";
+    dc-pin    = <&ssd1322>,"dc-gpios:4";
   };
 };


### PR DESCRIPTION
Note that in order to override overlay parameters via `config.txt`, the parameter specification must come *after* the overlay is included. Note that this change hasn't been tested on norns hardware proper but in theory it should be a no-op since the default values are for the norns hardware.

The relevant sections of the `config.txt` for the shield looks something like this:
```
...
# Display
# Connected using SPI
dtparam=spi=on
dtoverlay=ssd1322-spi
dtparam=dc-pin=7                                    # <<== new
dtparam=rotate=180                                 # <<== new

# Buttons and encoders
dtoverlay=norns-buttons-encoders
dtparam=e1_pin_a=4                                # <<== new from here to the bottom
dtparam=e1_pin_b=27
dtparam=e2_pin_a=24
dtparam=e2_pin_b=23
dtparam=e3_pin_a=12
dtparam=e3_pin_b=25
dtparam=b1_pin=22
dtparam=b2_pin=26
dtparam=b3_pin=5
``` 