### PR TITLE
CI: Allow manually triggering builds

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,6 +14,9 @@ on:
   # Run tests for any PRs.
   pull_request:
 
+  # Allow triggering manually
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
So we can easily (re)build an existing or older image.
See https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow for more info on how this works