### PR TITLE
Modify ssd1322 driver to use gamma + added precharge voltage device file.

### DIFF
--- a/drivers/staging/fbtft/fb_ssd1322.c
+++ b/drivers/staging/fbtft/fb_ssd1322.c
@@ -13,7 +13,8 @@
 #define HEIGHT      64
 #define GAMMA_NUM   1
 #define GAMMA_LEN   15
-#define DEFAULT_GAMMA "1 1 1 1 1 2 2 3 3 4 4 5 5 6 6"
+#define DEFAULT_GAMMA "0 8 8 8 8 8 8 8 8 8 8 8 8 8 8"
+#define DEFAULT_PRECHARGE "1F"
 
 static int init_display(struct fbtft_par *par)
 {
@@ -94,13 +95,26 @@ static int set_gamma(struct fbtft_par *par, u32 *curves)
 		}
 	}
 
-	//write_reg(par, 0xB8,
-	//0,1,2,3,4,5,6,7,8,
-	//9,10,15,25,30,35);
-	//tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7],
-	//tmp[8], tmp[9], tmp[10], tmp[11], tmp[12], tmp[13], tmp[14]);
-	//write_reg(par, 0);
-	
+	write_reg(par, 0xB8,
+	tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7],
+	tmp[8], tmp[9], tmp[10], tmp[11], tmp[12], tmp[13], tmp[14]);
+	write_reg(par, 0x00);
+
+	return 0;
+}
+
+static int set_precharge_voltage(struct fbtft_par *par, u32 *voltage)
+{
+	fbtft_par_dbg(DEBUG_INIT_DISPLAY, par, "%s()\n", __func__);
+
+	if (voltage == NULL) {
+		dev_err(par->info->device,
+			"Null pointer passed to set_precharge_voltage().\n");
+		return -EINVAL;
+	}
+
+	// Range: 0x00 - 0x1F
+	write_reg(par, 0xBB, voltage[0]);
 
 	return 0;
 }
@@ -174,12 +188,14 @@ static struct fbtft_display display = {
 	.gamma_num = GAMMA_NUM,
 	.gamma_len = GAMMA_LEN,
 	.gamma = DEFAULT_GAMMA,
+	.precharge = DEFAULT_PRECHARGE,
 	.fbtftops = {
 		.init_display = init_display,
 		.write_vmem = write_vmem,
 		.set_addr_win  = set_addr_win,
 		.blank = blank,
 		.set_gamma = set_gamma,
+		.set_precharge_voltage = set_precharge_voltage,
 	},
 };
 

--- a/drivers/staging/fbtft/fbtft.h
+++ b/drivers/staging/fbtft/fbtft.h
@@ -53,6 +53,7 @@ struct fbtft_par;
  * @set_var: Configure LCD with values from variables like @rotate and @bgr
  *           (optional)
  * @set_gamma: Set Gamma curve (optional)
+ * @set_precharge_voltage: Set pre-charge voltage (optional)
  *
  * Most of these operations have default functions assigned to them in
  *     fbtft_framebuffer_alloc()
@@ -82,6 +83,7 @@ struct fbtft_ops {
 
 	int (*set_var)(struct fbtft_par *par);
 	int (*set_gamma)(struct fbtft_par *par, u32 *curves);
+	int (*set_precharge_voltage)(struct fbtft_par *par, u32 *voltage);
 };
 
 /**
@@ -117,6 +119,7 @@ struct fbtft_display {
 	char *gamma;
 	int gamma_num;
 	int gamma_len;
+	char *precharge;
 	unsigned long debug;
 };
 
@@ -181,6 +184,7 @@ struct fbtft_platform_data {
  * @gamma.curves: Pointer to Gamma curve array
  * @gamma.num_values: Number of values per Gamma curve
  * @gamma.num_curves: Number of Gamma curves
+ * @precharge.voltage: 
  * @debug: Pointer to debug value
  * @current_debug:
  * @first_update_done: Used to only time the first display update
@@ -223,6 +227,10 @@ struct fbtft_par {
 		int num_values;
 		int num_curves;
 	} gamma;
+	struct {
+		struct mutex lock;
+		u32 *voltage;
+	} precharge;
 	unsigned long debug;
 	bool first_update_done;
 	ktime_t update_time;

--- a/drivers/staging/fbtft/internal.h
+++ b/drivers/staging/fbtft/internal.h
@@ -9,5 +9,7 @@ void fbtft_sysfs_exit(struct fbtft_par *par);
 void fbtft_expand_debug_value(unsigned long *debug);
 int fbtft_gamma_parse_str(struct fbtft_par *par, u32 *curves,
 			  const char *str, int size);
+int fbtft_precharge_parse_str(struct fbtft_par *par, u32 *voltage,
+			      const char *str, int size);
 
 #endif /* __LINUX_FBTFT_INTERNAL_H */


### PR DESCRIPTION
 - Made /sys/class/graphics/fbX/gamma accessible to all users.
 - Added /sys/class/graphics/fbX/precharge, accessible by all.
 - Added related "precharge" struct fields for fbtft core lib.
 - *Note: Used a macro trick in fbtft-sysfs.c to allow octal
          permissions of 0666 to "gamma" and "precharge.